### PR TITLE
Add Azure Terraforminator Action for Decommissioning Resource Groups

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,27 @@
+name: 'Azure Terraforminator Action '
+description: 'A GitHub Action that decommisions resource groups tagged with Temporay as TRUE'
+author: 'githubofkrishnadhas'
+# reference https://haya14busa.github.io/github-action-brandings/
+branding:
+    icon: 'cloud-lightning'
+    color: 'green'
+inputs:
+  subscription_name:
+    required: true
+    type: string
+    default: ""
+    description: "The azure subscription name."
+runs:
+  using: 'composite'
+  steps:
+    - name: Install Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    - name: package installations
+      run: |
+        pip install poetry
+        poetry install -v --no-root --no-interaction
+    - name: Run Python program
+      run: |
+        poetry run python3 terraforminator.py --subscription_name ${{ inputs.subscription_name }}


### PR DESCRIPTION
This PR introduces a GitHub Action named "Azure Terraforminator Action" that decommissions Azure resource groups tagged with "Temporary" as TRUE. The action installs necessary Python dependencies using Poetry and runs the terraforminator.py script with the provided Azure subscription name.

DEVOPS-313 convert azure terraforminator as action